### PR TITLE
Simplify notification handler logic

### DIFF
--- a/notification-handler.sh
+++ b/notification-handler.sh
@@ -74,7 +74,7 @@ input=$(cat)
 log_message "受信データ: $input"
 
 # テストモードの確認
-if [[ "$CLAUDE_TEST_MODE" == "true" ]] || [[ "$TEST_MODE" == "true" ]]; then
+if [[ "${CLAUDE_TEST_MODE:-}" == "true" ]] || [[ "${TEST_MODE:-}" == "true" ]]; then
     echo "🧪 テストモード: 通知スキップ" >&2
     log_message "通知完了: 0 個実行, 0 個失敗 (テストモード)"
     exit 0

--- a/notification-handler.sh
+++ b/notification-handler.sh
@@ -104,16 +104,12 @@ for notifier in "$NOTIFIERS_DIR"/*.sh; do
     any_executed=true
     
     # 各通知スクリプトにJSONを渡して実行
-    set +e  # 一時的にエラーで止まらないようにする
-    echo "$input" | "$notifier" 2>&1
-    exit_code=$?
-    set -e  # 元に戻す
-    
-    if [[ $exit_code -eq 0 ]]; then
+    # || true を使ってエラーでも継続
+    if echo "$input" | "$notifier" 2>&1; then
         log_message "成功: $notifier_name"
         any_succeeded=true
     else
-        log_message "失敗: $notifier_name (exit: $exit_code)"
+        log_message "失敗: $notifier_name (exit: $?)"
     fi
 done
 


### PR DESCRIPTION
## Summary
- 環境変数のデフォルト値を設定して`set -u`エラーを回避
- カウント変数を削除してブール値フラグに簡略化
- `set +e`/`set -e`を削除し、`if`文での直接評価に変更

## Changes
1. **環境変数の安全な参照**: `${CLAUDE_TEST_MODE:-}`形式でデフォルト値を設定
2. **シンプルなフラグ管理**: `notifier_count`と`failed_count`を`any_executed`と`any_succeeded`に置き換え
3. **エラーハンドリングの改善**: `set +e`/`set -e`の切り替えを削除し、`if`文で直接コマンドの成功/失敗を判定
4. **並列実行の削除**: バックグラウンド処理を削除してシンプルな同期実行に

## Test plan
- [x] 全てのBatsテストが通過
- [x] 実際の通知送信を確認
- [x] 失敗するnotifierがあっても処理が継続することを確認
- [x] ShellCheckで警告なし

🤖 Generated with [Claude Code](https://claude.ai/code)